### PR TITLE
Update to 26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -7,34 +7,33 @@ version = project.mod_version
 group = project.maven_group
 
 base {
-	archivesName = project.archives_base_name + "+" + project.minecraft_version
+	archivesName = project.archives_base_name
 }
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {
 	inputs.property "version", project.version
-    inputs.property "minecraft_version", project.minecraft_version
+	inputs.property "minecraft_version", project.minecraft_version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": project.version,
-                "minecraft_version": project.minecraft_version
+		expand "version": inputs.properties.version,
+                "minecraft_version": inputs.properties.minecraft_version
 	}
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
@@ -44,5 +43,5 @@ jar {
 }
 
 loom {
-    accessWidenerPath = file("src/main/resources/centered-crosshair.accesswidener")
+	accessWidenerPath = file("src/main/resources/centered-crosshair.accesswidener")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.1
-loader_version=0.18.1
+minecraft_version=26.1
+loader_version=0.18.5
+loom_version=1.15-SNAPSHOT
 
 # Mod Properties
 mod_version=1.4.0

--- a/src/main/java/me/wolfii/DrawContextFloatDrawTexture.java
+++ b/src/main/java/me/wolfii/DrawContextFloatDrawTexture.java
@@ -1,7 +1,7 @@
 package me.wolfii;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 
 public interface DrawContextFloatDrawTexture {
     default void centered_crosshair$drawGuiTexture(RenderPipeline pipeline, Identifier texture, float x, float y, int width, int height) {}

--- a/src/main/java/me/wolfii/SubpixelPositionedTexturedQuadGuiElementRenderState.java
+++ b/src/main/java/me/wolfii/SubpixelPositionedTexturedQuadGuiElementRenderState.java
@@ -1,10 +1,10 @@
 package me.wolfii;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-import net.minecraft.client.gui.ScreenRect;
-import net.minecraft.client.gui.render.state.SimpleGuiElementRenderState;
-import net.minecraft.client.render.VertexConsumer;
-import net.minecraft.client.texture.TextureSetup;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.gui.render.TextureSetup;
+import net.minecraft.client.renderer.state.gui.GuiElementRenderState;
 import org.joml.Matrix3x2f;
 
 public record SubpixelPositionedTexturedQuadGuiElementRenderState(
@@ -20,9 +20,9 @@ public record SubpixelPositionedTexturedQuadGuiElementRenderState(
     float v1,
     float v2,
     int color,
-    ScreenRect scissorArea,
-    ScreenRect bounds
-) implements SimpleGuiElementRenderState {
+    ScreenRectangle scissorArea,
+    ScreenRectangle bounds
+) implements GuiElementRenderState {
     public SubpixelPositionedTexturedQuadGuiElementRenderState(
         RenderPipeline pipeline,
         TextureSetup textureSetup,
@@ -36,21 +36,21 @@ public record SubpixelPositionedTexturedQuadGuiElementRenderState(
         float v1,
         float v2,
         int color,
-        ScreenRect scissorArea
+        ScreenRectangle scissorArea
     ) {
         this(pipeline, textureSetup, pose, x1, y1, x2, y2, u1, u2, v1, v2, color, scissorArea, createBounds(x1, y1, x2, y2, pose, scissorArea));
     }
 
     @Override
-    public void setupVertices(VertexConsumer vertices) {
-        vertices.vertex(this.pose(), this.x1(), this.y1()).texture(this.u1(), this.v1()).color(this.color());
-        vertices.vertex(this.pose(), this.x1(), this.y2()).texture(this.u1(), this.v2()).color(this.color());
-        vertices.vertex(this.pose(), this.x2(), this.y2()).texture(this.u2(), this.v2()).color(this.color());
-        vertices.vertex(this.pose(), this.x2(), this.y1()).texture(this.u2(), this.v1()).color(this.color());
+    public void buildVertices(VertexConsumer vertices) {
+        vertices.addVertexWith2DPose(this.pose(), this.x1(), this.y1()).setUv(this.u1(), this.v1()).setColor(this.color());
+        vertices.addVertexWith2DPose(this.pose(), this.x1(), this.y2()).setUv(this.u1(), this.v2()).setColor(this.color());
+        vertices.addVertexWith2DPose(this.pose(), this.x2(), this.y2()).setUv(this.u2(), this.v2()).setColor(this.color());
+        vertices.addVertexWith2DPose(this.pose(), this.x2(), this.y1()).setUv(this.u2(), this.v1()).setColor(this.color());
     }
 
-    private static ScreenRect createBounds(float x1, float y1, float x2, float y2, Matrix3x2f pose, ScreenRect scissorArea) {
-        ScreenRect screenRect = new ScreenRect(Math.round(x1), Math.round(y1), Math.round(x2 - x1), Math.round(y2 - y1)).transformEachVertex(pose);
+    private static ScreenRectangle createBounds(float x1, float y1, float x2, float y2, Matrix3x2f pose, ScreenRectangle scissorArea) {
+        ScreenRectangle screenRect = new ScreenRectangle(Math.round(x1), Math.round(y1), Math.round(x2 - x1), Math.round(y2 - y1)).transformMaxBounds(pose);
         return scissorArea != null ? scissorArea.intersection(screenRect) : screenRect;
     }
 }

--- a/src/main/java/me/wolfii/mixin/DrawContextMixin.java
+++ b/src/main/java/me/wolfii/mixin/DrawContextMixin.java
@@ -3,14 +3,14 @@ package me.wolfii.mixin;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import me.wolfii.DrawContextFloatDrawTexture;
 import me.wolfii.SubpixelPositionedTexturedQuadGuiElementRenderState;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.render.state.GuiRenderState;
-import net.minecraft.client.texture.AbstractTexture;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.client.texture.SpriteAtlasTexture;
-import net.minecraft.client.texture.TextureSetup;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.render.TextureSetup;
+import net.minecraft.client.renderer.state.gui.GuiRenderState;
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.resources.Identifier;
 import org.joml.Matrix3x2f;
 import org.joml.Matrix3x2fStack;
 import org.spongepowered.asm.mixin.Final;
@@ -18,50 +18,50 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
-@Mixin(DrawContext.class)
+@Mixin(GuiGraphicsExtractor.class)
 public class DrawContextMixin implements DrawContextFloatDrawTexture {
     @Shadow
     @Final
-    private SpriteAtlasTexture spriteAtlasTexture;
+    private TextureAtlas guiSprites;
     @Shadow
     @Final
-	GuiRenderState state;
+	GuiRenderState guiRenderState;
     @Shadow
     @Final
-	MinecraftClient client;
+	Minecraft minecraft;
     @Shadow
     @Final
-    private Matrix3x2fStack matrices;
+    private Matrix3x2fStack pose;
     @Shadow
     @Final
-    private DrawContext.ScissorStack scissorStack;
+    private GuiGraphicsExtractor.ScissorStack scissorStack;
 
     @Unique
     public void centered_crosshair$drawGuiTexture(RenderPipeline pipeline, Identifier texture, float x, float y, int width, int height) {
         if (width == 0 || height == 0) return;
-        Sprite sprite = this.spriteAtlasTexture.getSprite(texture);
+        TextureAtlasSprite sprite = this.guiSprites.getSprite(texture);
         this.drawTexturedQuad(
             pipeline,
-            sprite.getAtlasId(),
+            sprite.atlasLocation(),
             x,
             x + width,
             y,
             y + height,
-            sprite.getMinU() + (0b1 / 32768f),
-            sprite.getMaxU() + (0b1 / 32768f),
-            sprite.getMinV() - (0b1 / 32768f),
-            sprite.getMaxV() - (0b1 / 32768f),
+            sprite.getU0() + (0b1 / 32768f),
+            sprite.getU1() + (0b1 / 32768f),
+            sprite.getV0() - (0b1 / 32768f),
+            sprite.getV1() - (0b1 / 32768f),
             -1
         );
     }
 
     @Unique
     void drawTexturedQuad(RenderPipeline pipeline, Identifier sprite, float x1, float x2, float y1, float y2, float u1, float u2, float v1, float v2, int color) {
-		AbstractTexture abstractTexture = this.client.getTextureManager().getTexture(sprite);
-        this.state.addSimpleElement(new SubpixelPositionedTexturedQuadGuiElementRenderState(
+		AbstractTexture abstractTexture = this.minecraft.getTextureManager().getTexture(sprite);
+        this.guiRenderState.addGuiElement(new SubpixelPositionedTexturedQuadGuiElementRenderState(
             pipeline,
-            TextureSetup.of(abstractTexture.getGlTextureView(), abstractTexture.getSampler()),
-            new Matrix3x2f(this.matrices),
+            TextureSetup.singleTexture(abstractTexture.getTextureView(), abstractTexture.getSampler()),
+            new Matrix3x2f(this.pose),
             x1,
             y1,
             x2,
@@ -71,7 +71,7 @@ public class DrawContextMixin implements DrawContextFloatDrawTexture {
             v1,
             v2,
             color,
-            this.scissorStack.peekLast()
+            this.scissorStack.peek()
         ));
     }
 }

--- a/src/main/java/me/wolfii/mixin/InGameHudMixin.java
+++ b/src/main/java/me/wolfii/mixin/InGameHudMixin.java
@@ -1,28 +1,29 @@
 package me.wolfii.mixin;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.hud.InGameHud;
-import net.minecraft.util.Identifier;
+import me.wolfii.DrawContextFloatDrawTexture;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(InGameHud.class)
+@Mixin(Gui.class)
 public class InGameHudMixin {
     @Redirect(
-        method = "renderCrosshair",
+        method = "extractCrosshair",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/util/Identifier;IIII)V", ordinal = 0
+            target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;blitSprite(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIII)V", ordinal = 0
         )
     )
-    private void drawTextureRedirect(DrawContext instance, RenderPipeline pipeline, Identifier sprite, int x, int y, int width, int height) {
-        float scaleFactor = (float) MinecraftClient.getInstance().getWindow().getScaleFactor();
-        float scaledCenterX = (MinecraftClient.getInstance().getWindow().getFramebufferWidth() / scaleFactor) / 2f;
-        float scaledCenterY = (MinecraftClient.getInstance().getWindow().getFramebufferHeight() / scaleFactor) / 2f;
-        instance.centered_crosshair$drawGuiTexture(
+    private void drawTextureRedirect(GuiGraphicsExtractor instance, RenderPipeline pipeline, Identifier sprite, int x, int y, int width, int height) {
+        float scaleFactor = (float) Minecraft.getInstance().getWindow().getGuiScale();
+        float scaledCenterX = (Minecraft.getInstance().getWindow().getWidth() / scaleFactor) / 2f;
+        float scaledCenterY = (Minecraft.getInstance().getWindow().getHeight() / scaleFactor) / 2f;
+        ((DrawContextFloatDrawTexture) instance).centered_crosshair$drawGuiTexture(
             pipeline,
             sprite,
             Math.round((scaledCenterX - 7.5f) * 4) / 4f,

--- a/src/main/resources/centered-crosshair.accesswidener
+++ b/src/main/resources/centered-crosshair.accesswidener
@@ -1,3 +1,2 @@
-accessWidener v2 named
-
-accessible class net/minecraft/client/gui/DrawContext$ScissorStack
+accessWidener v2 official
+accessible class net/minecraft/client/gui/GuiGraphicsExtractor$ScissorStack


### PR DESCRIPTION
Migrated to official mappings
You can change the class and function names to match official mappings if you want. Just don't change the name of "centered_crosshair$drawGuiTexture" since mods that add support for this use it.